### PR TITLE
Update mkdocstrings-python to 1.10.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can install the Frequenz Electricity Trading API client via pip. Replace `VE
 
 ```
 # Choose the version you want to install
-VERSION=0.1.0
+VERSION=0.2.0
 pip install frequenz-client-electricity-trading==$VERSION
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev-mkdocs = [
   "mkdocs-macros-plugin == 1.0.5",
   "mkdocs-material == 9.5.31",
   "mkdocstrings[python] == 0.25.2",
-  "mkdocstrings-python == 1.10.7",
+  "mkdocstrings-python == 1.10.8",
   "frequenz-repo-config[lib] == 0.10.0",
 ]
 dev-mypy = [


### PR DESCRIPTION
There was an error in the CI pipeline, it complained about it cannot import name 'patch_logger' from 'griffe'.
Updating to the latest version of mkdocstrings-python should fix this issue.
