### PR TITLE
Fix publishing packaging error

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can install the Frequenz Electricity Trading API client via pip. Replace `VE
 
 ```
 # Choose the version you want to install
-VERSION=0.2.0
+VERSION=0.2.2
 pip install frequenz-client-electricity-trading==$VERSION
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "grpcio >= 1.60.0, < 2",
   "frequenz-channels >= 1.0.0, < 2",
   "frequenz-client-base[grpcio] >= 0.5.0, < 0.6.0",
-  "frequenz-api-electricity-trading @ git+https://github.com/frequenz-floss/frequenz-api-electricity-trading@8d89155",
+  "frequenz-api-electricity-trading >= 0.2.2, < 1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The CI pipeline previously failed to publish the package to PyPI because of a direct dependency on a git repository.

HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/ Can't have direct dependency: frequenz-api-electricity-trading@ git+https://github.com/frequenz-floss/frequenz-api-electricity-trading@ 8d89155. See https://packaging.python.org/specifications/core-metadata for more information.