### PR TITLE
Fix list gridpool orders

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,5 @@
 # Frequenz Electricity Trading API Client Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
-## New Features
-
-<!-- Here goes the main new features and examples or instructions on how to use them -->
-
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+- Fixed list gridpool orders to log an error when an order conversion from protobuf failed and continuing to process other orders.

--- a/src/frequenz/client/electricity_trading/_client.py
+++ b/src/frequenz/client/electricity_trading/_client.py
@@ -639,10 +639,17 @@ class Client(BaseApiClient[ElectricityTradingServiceStub, grpc.aio.Channel]):
                 ),
             )
 
-            return [
-                OrderDetail.from_pb(order_detail)
-                for order_detail in response.order_details
-            ]
+            orders: list[OrderDetail] = []
+            for order_detail in response.order_details:
+                try:
+                    orders.append(OrderDetail.from_pb(order_detail))
+                except InvalidOperation:
+                    _logger.error(
+                        "Failed to convert order details for order: %s",
+                        str(order_detail).replace("\n", ""),
+                    )
+
+            return orders
         except grpc.RpcError as e:
             _logger.exception("Error occurred while listing gridpool orders: %s", e)
             raise e


### PR DESCRIPTION
Log the error if a grid pool order detail cannot be converted from the protobuf message to the OrderDetail object. But continue processing the other order details.