### PR TITLE
Add CLI command to create limit orders

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,9 @@
   * `list-day-ahead`: Listing day-ahead prices from the entsoe API.
   * `list-trades`: Listing and streaming public trades for specified delivery periods. If no delivery start is given, starts streaming all new public trades.
   * `list-orders`: Listing and streaming orders for specified delivery periods and gridpool IDs. If no delivery start is given, starts streaming all new orders for this gridpool ID.
+  * `create-order`: Creating a limit order for a given price (in EUR/MWh) and quantity (in MW, sign determines market side).
+  * `cancel-order`: Cancel individual orders for a gridpool.
+  * `cancel-all-orders`: Cancels all orders of a gridpool.
 
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->

--- a/src/frequenz/client/electricity_trading/cli/__main__.py
+++ b/src/frequenz/client/electricity_trading/cli/__main__.py
@@ -11,6 +11,9 @@ import click
 
 from frequenz.client.electricity_trading.cli.day_ahead import list_day_ahead_prices
 from frequenz.client.electricity_trading.cli.etrading import (
+    create_order as run_create_order,
+)
+from frequenz.client.electricity_trading.cli.etrading import (
     list_orders as run_list_orders,
 )
 from frequenz.client.electricity_trading.cli.etrading import (
@@ -52,6 +55,51 @@ def list_trades(url: str, key: str, *, start: datetime) -> None:
 def list_orders(url: str, key: str, *, start: datetime, gid: int) -> None:
     """List orders."""
     asyncio.run(run_list_orders(url=url, key=key, delivery_start=start, gid=gid))
+
+
+@cli.command()
+@click.option("--url", required=True, type=str)
+@click.option("--key", required=True, type=str)
+@click.option("--start", required=True, type=iso)
+@click.option("--gid", required=True, type=int)
+@click.option("--quantity", required=True, type=str)
+@click.option("--price", required=True, type=str)
+@click.option("--area", required=True, type=str)
+@click.option("--currency", default="EUR", type=str)
+@click.option("--duration", default=900, type=int)
+def create_order(
+    # pylint: disable=too-many-arguments
+    url: str,
+    key: str,
+    *,
+    start: datetime,
+    gid: int,
+    quantity: str,
+    price: str,
+    area: str,
+    currency: str,
+    duration: int,
+) -> None:
+    """Create an order.
+
+    This is only allowed in test instances.
+    """
+    if "test" not in url:
+        raise ValueError("Creating orders is only allowed in test instances.")
+
+    asyncio.run(
+        run_create_order(
+            url=url,
+            key=key,
+            delivery_start=start,
+            gid=gid,
+            quantity_mw=quantity,
+            price=price,
+            delivery_area=area,
+            currency=currency,
+            duration=timedelta(seconds=duration),
+        )
+    )
 
 
 @cli.command()

--- a/src/frequenz/client/electricity_trading/cli/__main__.py
+++ b/src/frequenz/client/electricity_trading/cli/__main__.py
@@ -11,6 +11,9 @@ import click
 
 from frequenz.client.electricity_trading.cli.day_ahead import list_day_ahead_prices
 from frequenz.client.electricity_trading.cli.etrading import (
+    cancel_order as run_cancel_order,
+)
+from frequenz.client.electricity_trading.cli.etrading import (
     create_order as run_create_order,
 )
 from frequenz.client.electricity_trading.cli.etrading import (
@@ -100,6 +103,25 @@ def create_order(
             duration=timedelta(seconds=duration),
         )
     )
+
+
+@cli.command()
+@click.option("--url", required=True, type=str)
+@click.option("--key", required=True, type=str)
+@click.option("--gid", required=True, type=int)
+@click.option("--order", required=True, type=int)
+def cancel_order(url: str, key: str, gid: int, order: int) -> None:
+    """Cancel an order."""
+    asyncio.run(run_cancel_order(url=url, key=key, gridpool_id=gid, order_id=order))
+
+
+@cli.command()
+@click.option("--url", required=True, type=str)
+@click.option("--key", required=True, type=str)
+@click.option("--gid", required=True, type=int)
+def cancel_all_orders(url: str, key: str, gid: int) -> None:
+    """Cancel all orders for a gridpool ID."""
+    asyncio.run(run_cancel_order(url=url, key=key, gridpool_id=gid, order_id=None))
 
 
 @cli.command()

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -172,6 +172,26 @@ async def create_order(
     print_order(order)
 
 
+async def cancel_order(
+    url: str, key: str, *, gridpool_id: int, order_id: int | None
+) -> None:
+    """Cancel an order by order ID.
+
+    If order_id is None, cancel all orders in the gridpool.
+
+    Args:
+        url: URL of the trading API.
+        key: API key.
+        gridpool_id: Gridpool ID.
+        order_id: Order ID to cancel or None to cancel all orders.
+    """
+    client = Client(server_url=url, auth_key=key)
+    if order_id is None:
+        await client.cancel_all_gridpool_orders(gridpool_id)
+    else:
+        await client.cancel_gridpool_order(gridpool_id, order_id)
+
+
 def print_trade_header() -> None:
     """Print trade header in CSV format."""
     header = (


### PR DESCRIPTION
The command allows creating a limit order on a test instance. The market side is derived from the sign of the quantity. For now only delivery periods of 15 min and delivery area codes in EUROPE_EIC format are supported.

In addition to that the sort order of listed orders is reversed such that oldest orders are listed at the bottom (restricted within chunks).