### PR TITLE
Rename list_ commands in CLI tool

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,8 +12,8 @@
 
 * Add trading-cli tool to interact with the trading API. Supports the following commands:
   * `list-day-ahead`: Listing day-ahead prices from the entsoe API.
-  * `list-trades`: Listing and streaming public trades for specified delivery periods. If no delivery start is given, starts streaming all new public trades.
-  * `list-orders`: Listing and streaming orders for specified delivery periods and gridpool IDs. If no delivery start is given, starts streaming all new orders for this gridpool ID.
+  * `receive-trades`: Listing and streaming public trades for specified delivery periods. If no delivery start is given, starts streaming all new public trades.
+  * `receive-orders`: Listing and streaming orders for specified delivery periods and gridpool IDs. If no delivery start is given, starts streaming all new orders for this gridpool ID.
   * `create-order`: Creating a limit order for a given price (in EUR/MWh) and quantity (in MW, sign determines market side).
   * `cancel-order`: Cancel individual orders for a gridpool.
   * `cancel-all-orders`: Cancels all orders of a gridpool.

--- a/src/frequenz/client/electricity_trading/cli/__main__.py
+++ b/src/frequenz/client/electricity_trading/cli/__main__.py
@@ -45,8 +45,8 @@ def cli() -> None:
 @click.option("--url", required=True, type=str)
 @click.option("--key", required=True, type=str)
 @click.option("--start", default=None, type=iso)
-def list_trades(url: str, key: str, *, start: datetime) -> None:
-    """List trades."""
+def receive_trades(url: str, key: str, *, start: datetime) -> None:
+    """List and/or stream trades."""
     asyncio.run(run_list_trades(url=url, key=key, delivery_start=start))
 
 
@@ -55,8 +55,8 @@ def list_trades(url: str, key: str, *, start: datetime) -> None:
 @click.option("--key", required=True, type=str)
 @click.option("--start", default=None, type=iso)
 @click.option("--gid", required=True, type=int)
-def list_orders(url: str, key: str, *, start: datetime, gid: int) -> None:
-    """List orders."""
+def receive_orders(url: str, key: str, *, start: datetime, gid: int) -> None:
+    """List and/or stream orders."""
     asyncio.run(run_list_orders(url=url, key=key, delivery_start=start, gid=gid))
 
 


### PR DESCRIPTION
Fixes https://github.com/frequenz-floss/frequenz-client-electricity-trading-python/issues/98