### PR TITLE
Add receive-gridpool-trades command to CLI tool

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 ## New Features
 
 * Add helper function to support creating quantities that conform to the API expectations.
+* Add `receive-gridpool-trades` command to CLI tool.
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 

--- a/src/frequenz/client/electricity_trading/cli/__main__.py
+++ b/src/frequenz/client/electricity_trading/cli/__main__.py
@@ -17,6 +17,9 @@ from frequenz.client.electricity_trading.cli.etrading import (
     create_order as run_create_order,
 )
 from frequenz.client.electricity_trading.cli.etrading import (
+    list_gridpool_trades as run_list_gridpool_trades,
+)
+from frequenz.client.electricity_trading.cli.etrading import (
     list_orders as run_list_orders,
 )
 from frequenz.client.electricity_trading.cli.etrading import (
@@ -48,6 +51,18 @@ def cli() -> None:
 def receive_trades(url: str, key: str, *, start: datetime) -> None:
     """List and/or stream trades."""
     asyncio.run(run_list_trades(url=url, key=key, delivery_start=start))
+
+
+@cli.command()
+@click.option("--url", required=True, type=str)
+@click.option("--key", required=True, type=str)
+@click.option("--gid", required=True, type=int)
+@click.option("--start", default=None, type=iso)
+def receive_gridpool_trades(url: str, key: str, gid: int, *, start: datetime) -> None:
+    """List and/or stream orders."""
+    asyncio.run(
+        run_list_gridpool_trades(url=url, key=key, gid=gid, delivery_start=start)
+    )
 
 
 @cli.command()

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -54,7 +54,7 @@ async def list_trades(url: str, key: str, *, delivery_start: datetime) -> None:
     """
     client = Client(server_url=url, auth_key=key)
 
-    print_trade_header()
+    print_public_trade_header()
 
     delivery_period = None
     # If delivery period is selected, list historical trades also
@@ -67,14 +67,14 @@ async def list_trades(url: str, key: str, *, delivery_start: datetime) -> None:
         lst = client.list_public_trades(delivery_period=delivery_period)
 
         async for trade in lst:
-            print_trade(trade)
+            print_public_trade(trade)
 
         if delivery_start <= datetime.now(timezone.utc):
             return
 
     stream = await client.stream_public_trades(delivery_period=delivery_period)
     async for trade in stream:
-        print_trade(trade)
+        print_public_trade(trade)
 
 
 async def list_orders(
@@ -197,7 +197,7 @@ async def cancel_order(
         await client.cancel_gridpool_order(gridpool_id, order_id)
 
 
-def print_trade_header() -> None:
+def print_public_trade_header() -> None:
     """Print trade header in CSV format."""
     header = (
         "public_trade_id,"
@@ -216,7 +216,7 @@ def print_trade_header() -> None:
     print(header)
 
 
-def print_trade(trade: PublicTrade) -> None:
+def print_public_trade(trade: PublicTrade) -> None:
     """Print trade details to stdout in CSV format."""
     values = (
         trade.public_trade_id,

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -21,6 +21,7 @@ from frequenz.client.electricity_trading import (
     Power,
     Price,
     PublicTrade,
+    Trade,
 )
 
 
@@ -75,6 +76,44 @@ async def list_trades(url: str, key: str, *, delivery_start: datetime) -> None:
     stream = await client.stream_public_trades(delivery_period=delivery_period)
     async for trade in stream:
         print_public_trade(trade)
+
+
+async def list_gridpool_trades(
+    url: str, key: str, gid: int, *, delivery_start: datetime
+) -> None:
+    """List gridpool trades and stream new gridpool trades.
+
+    Optionally a delivery_start can be provided to filter the trades by delivery period.
+
+    Args:
+        url: URL of the trading API.
+        key: API key.
+        gid: Gridpool ID.
+        delivery_start: Start of the delivery period or None.
+    """
+    client = Client(server_url=url, auth_key=key)
+
+    print_trade_header()
+
+    delivery_period = None
+    # If delivery period is selected, list historical trades also
+    if delivery_start is not None:
+        check_delivery_start(delivery_start)
+        delivery_period = DeliveryPeriod(
+            start=delivery_start,
+            duration=timedelta(minutes=15),
+        )
+    lst = client.list_gridpool_trades(gid, delivery_period=delivery_period)
+
+    async for trade in lst:
+        print_trade(trade)
+
+    if delivery_start and delivery_start <= datetime.now(timezone.utc):
+        return
+
+    stream = await client.stream_gridpool_trades(gid, delivery_period=delivery_period)
+    async for trade in stream:
+        print_trade(trade)
 
 
 async def list_orders(
@@ -227,6 +266,44 @@ def print_public_trade(trade: PublicTrade) -> None:
         trade.sell_delivery_area.code,
         trade.buy_delivery_area.code_type,
         trade.sell_delivery_area.code_type,
+        trade.quantity.mw,
+        trade.price.currency,
+        trade.price.amount,
+        trade.state,
+    )
+    print(",".join(v.name if isinstance(v, Enum) else str(v) for v in values))
+
+
+def print_trade_header() -> None:
+    """Print trade header in CSV format."""
+    header = (
+        "trade_id,"
+        "order_id,"
+        "execution_time,"
+        "delivery_period_start,"
+        "delivery_period_duration,"
+        "delivery_area_code,"
+        "delivery_area_code_type,"
+        "side,"
+        "quantity_mw,"
+        "currency,"
+        "price,"
+        "state "
+    )
+    print(header)
+
+
+def print_trade(trade: Trade) -> None:
+    """Print trade details to stdout in CSV format."""
+    values = (
+        trade.id,
+        trade.order_id,
+        trade.execution_time.isoformat(),
+        trade.delivery_period.start.isoformat(),
+        trade.delivery_period.duration,
+        trade.delivery_area.code,
+        trade.delivery_area.code_type,
+        trade.side,
         trade.quantity.mw,
         trade.price.currency,
         trade.price.amount,


### PR DESCRIPTION
Similarly to list-gridpool-orders this list trades for a given gridpool ID and optionally contract delivery start.