### PR TITLE
Print tags on orders in CLI tool

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,10 +10,7 @@
 
 ## New Features
 
-* Add helper function to support creating quantities that conform to the API expectations.
-* Add `receive-gridpool-trades` command to CLI tool.
-* Add the `warn_on_overflow` option to the streaming receivers to allow ignoring overflow warnings
-* Add the `max_size` option to the streaming receivers
+* Print tags and filled (instead of open) quantity for gridpool orders in CLI tool.
 
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -328,7 +328,8 @@ def print_order_header() -> None:
         "side,"
         "currency,"
         "price,"
-        "state"
+        "state,"
+        "tag"
     )
     print(header)
 
@@ -344,7 +345,6 @@ def print_order(order: OrderDetail) -> None:
     - order.execution_option
     - order.valid_until
     - order.payload
-    - order.tag
     - state_detail.state_reason
     - state_detail.market_actor
     - open_quantity
@@ -367,6 +367,7 @@ def print_order(order: OrderDetail) -> None:
         order.order.price.currency,
         order.order.price.amount,
         order.state_detail.state,
+        order.order.tag,
     ]
     print(",".join(v.name if isinstance(v, Enum) else str(v) for v in values))
 

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -324,7 +324,7 @@ def print_order_header() -> None:
         "delivery_area_code_type,"
         "order_type,"
         "quantity_mw,"
-        "open_quantity_mw,"
+        "filled_quantity_mw,"
         "side,"
         "currency,"
         "price,"
@@ -347,7 +347,7 @@ def print_order(order: OrderDetail) -> None:
     - order.tag
     - state_detail.state_reason
     - state_detail.market_actor
-    - filled_quantity
+    - open_quantity
 
     Args:
         order: OrderDetail object
@@ -362,7 +362,7 @@ def print_order(order: OrderDetail) -> None:
         order.order.delivery_area.code_type,
         order.order.type,
         order.order.quantity.mw,
-        order.open_quantity.mw,
+        order.filled_quantity.mw,
         order.order.side,
         order.order.price.currency,
         order.order.price.amount,


### PR DESCRIPTION
Print filled instead of open quantity in CLI tool because the latter is derived from the former.