### PR TITLE
Return `GrpcStreamBroadcaster` instances from the streaming methods

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
     * Rename `receive_trades` to `receive_public_trades`
     * Rename `receive_orders` to `receive_gridpool_orders`
 
+- The `stream_*` methods in the client have been renamed to `*_stream`.  They no longer return `Receiver` instances, but rather `GrpcStreamBroadcaster` instances.  They expose a `new_receiver()` method which can be used to get a new receiver.  They also expose a `stop()` method which can be used to stop the background streaming task when the stream is no longer needed.
+
 ## New Features
 
 * Print tags and filled (instead of open) quantity for gridpool orders in CLI tool.

--- a/src/frequenz/client/electricity_trading/_client.py
+++ b/src/frequenz/client/electricity_trading/_client.py
@@ -218,7 +218,7 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
         # type-checker, so it can only be used for type hints.
         return self._stub  # type: ignore
 
-    async def stream_gridpool_orders(
+    def stream_gridpool_orders(
         # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         gridpool_id: int,
@@ -285,7 +285,7 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
             warn_on_overflow=warn_on_overflow, maxsize=max_size
         )
 
-    async def stream_gridpool_trades(
+    def stream_gridpool_trades(
         # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         gridpool_id: int,
@@ -351,7 +351,7 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
             warn_on_overflow=warn_on_overflow, maxsize=max_size
         )
 
-    async def stream_public_trades(
+    def stream_public_trades(
         # pylint: disable=too-many-arguments, too-many-positional-arguments
         self,
         states: list[TradeState] | None = None,

--- a/src/frequenz/client/electricity_trading/_client.py
+++ b/src/frequenz/client/electricity_trading/_client.py
@@ -258,7 +258,10 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
 
         stream_key = (gridpool_id, gridpool_order_filter)
 
-        if stream_key not in self._gridpool_orders_streams:
+        if (
+            stream_key not in self._gridpool_orders_streams
+            or not self._gridpool_orders_streams[stream_key].is_running
+        ):
             try:
                 self._gridpool_orders_streams[stream_key] = GrpcStreamBroadcaster(
                     f"electricity-trading-{stream_key}",
@@ -319,7 +322,10 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
 
         stream_key = (gridpool_id, gridpool_trade_filter)
 
-        if stream_key not in self._gridpool_trades_streams:
+        if (
+            stream_key not in self._gridpool_trades_streams
+            or not self._gridpool_trades_streams[stream_key].is_running
+        ):
             try:
                 self._gridpool_trades_streams[stream_key] = GrpcStreamBroadcaster(
                     f"electricity-trading-{stream_key}",
@@ -373,7 +379,10 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
             sell_delivery_area=sell_delivery_area,
         )
 
-        if public_trade_filter not in self._public_trades_streams:
+        if (
+            public_trade_filter not in self._public_trades_streams
+            or not self._public_trades_streams[public_trade_filter].is_running
+        ):
             try:
                 self._public_trades_streams[public_trade_filter] = (
                     GrpcStreamBroadcaster(

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -73,7 +73,7 @@ async def list_public_trades(url: str, key: str, *, delivery_start: datetime) ->
         if delivery_start <= datetime.now(timezone.utc):
             return
 
-    stream = client.stream_public_trades(delivery_period=delivery_period)
+    stream = client.public_trades_stream(delivery_period=delivery_period).new_receiver()
     async for trade in stream:
         print_public_trade(trade)
 
@@ -111,7 +111,9 @@ async def list_gridpool_trades(
     if delivery_start and delivery_start <= datetime.now(timezone.utc):
         return
 
-    stream = client.stream_gridpool_trades(gid, delivery_period=delivery_period)
+    stream = client.gridpool_trades_stream(
+        gid, delivery_period=delivery_period
+    ).new_receiver()
     async for trade in stream:
         print_trade(trade)
 
@@ -154,7 +156,9 @@ async def list_gridpool_orders(
     if delivery_start and delivery_start <= datetime.now(timezone.utc):
         return
 
-    stream = client.stream_gridpool_orders(gid, delivery_period=delivery_period)
+    stream = client.gridpool_orders_stream(
+        gid, delivery_period=delivery_period
+    ).new_receiver()
     async for order in stream:
         print_order(order)
 

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -73,7 +73,7 @@ async def list_public_trades(url: str, key: str, *, delivery_start: datetime) ->
         if delivery_start <= datetime.now(timezone.utc):
             return
 
-    stream = await client.stream_public_trades(delivery_period=delivery_period)
+    stream = client.stream_public_trades(delivery_period=delivery_period)
     async for trade in stream:
         print_public_trade(trade)
 
@@ -111,7 +111,7 @@ async def list_gridpool_trades(
     if delivery_start and delivery_start <= datetime.now(timezone.utc):
         return
 
-    stream = await client.stream_gridpool_trades(gid, delivery_period=delivery_period)
+    stream = client.stream_gridpool_trades(gid, delivery_period=delivery_period)
     async for trade in stream:
         print_trade(trade)
 
@@ -154,7 +154,7 @@ async def list_gridpool_orders(
     if delivery_start and delivery_start <= datetime.now(timezone.utc):
         return
 
-    stream = await client.stream_gridpool_orders(gid, delivery_period=delivery_period)
+    stream = client.stream_gridpool_orders(gid, delivery_period=delivery_period)
     async for order in stream:
         print_order(order)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -131,27 +131,23 @@ def set_up_order_detail_response(
     ).to_pb()
 
 
-def test_stream_gridpool_orders(set_up: SetupParams) -> None:
+async def test_stream_gridpool_orders(set_up: SetupParams) -> None:
     """Test the method streaming gridpool orders."""
-    set_up.loop.run_until_complete(
-        set_up.client.stream_gridpool_orders(set_up.gridpool_id)
-    )
+    set_up.client.stream_gridpool_orders(set_up.gridpool_id)
+    await asyncio.sleep(0)
 
     set_up.mock_stub.ReceiveGridpoolOrdersStream.assert_called_once()
     args, _ = set_up.mock_stub.ReceiveGridpoolOrdersStream.call_args
     assert args[0].gridpool_id == set_up.gridpool_id
 
 
-def test_stream_gridpool_orders_with_optional_inputs(set_up: SetupParams) -> None:
+async def test_stream_gridpool_orders_with_optional_inputs(set_up: SetupParams) -> None:
     """Test the method streaming gridpool orders with some fields to filter for."""
     # Fields to filter for
     order_states = [OrderState.ACTIVE]
 
-    set_up.loop.run_until_complete(
-        set_up.client.stream_gridpool_orders(
-            set_up.gridpool_id, order_states=order_states
-        )
-    )
+    set_up.client.stream_gridpool_orders(set_up.gridpool_id, order_states=order_states)
+    await asyncio.sleep(0)
 
     set_up.mock_stub.ReceiveGridpoolOrdersStream.assert_called_once()
     args, _ = set_up.mock_stub.ReceiveGridpoolOrdersStream.call_args
@@ -161,15 +157,14 @@ def test_stream_gridpool_orders_with_optional_inputs(set_up: SetupParams) -> Non
     ]
 
 
-def test_stream_gridpool_trades(
+async def test_stream_gridpool_trades(
     set_up: SetupParams,
 ) -> None:
     """Test the method streaming gridpool trades."""
-    set_up.loop.run_until_complete(
-        set_up.client.stream_gridpool_trades(
-            gridpool_id=set_up.gridpool_id, market_side=set_up.side
-        )
+    set_up.client.stream_gridpool_trades(
+        gridpool_id=set_up.gridpool_id, market_side=set_up.side
     )
+    await asyncio.sleep(0)
 
     set_up.mock_stub.ReceiveGridpoolTradesStream.assert_called_once()
     args, _ = set_up.mock_stub.ReceiveGridpoolTradesStream.call_args
@@ -177,16 +172,15 @@ def test_stream_gridpool_trades(
     assert args[0].filter.side == set_up.side.to_pb()
 
 
-def test_stream_public_trades(
+async def test_stream_public_trades(
     set_up: SetupParams,
 ) -> None:
     """Test the method streaming public trades."""
     # Fields to filter for
     trade_states = [TradeState.ACTIVE]
 
-    set_up.loop.run_until_complete(
-        set_up.client.stream_public_trades(states=trade_states)
-    )
+    set_up.client.stream_public_trades(states=trade_states)
+    await asyncio.sleep(0)
 
     set_up.mock_stub.ReceivePublicTradesStream.assert_called_once()
     args, _ = set_up.mock_stub.ReceivePublicTradesStream.call_args

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,7 +133,7 @@ def set_up_order_detail_response(
 
 async def test_stream_gridpool_orders(set_up: SetupParams) -> None:
     """Test the method streaming gridpool orders."""
-    set_up.client.stream_gridpool_orders(set_up.gridpool_id)
+    set_up.client.gridpool_orders_stream(set_up.gridpool_id)
     await asyncio.sleep(0)
 
     set_up.mock_stub.ReceiveGridpoolOrdersStream.assert_called_once()
@@ -146,7 +146,7 @@ async def test_stream_gridpool_orders_with_optional_inputs(set_up: SetupParams) 
     # Fields to filter for
     order_states = [OrderState.ACTIVE]
 
-    set_up.client.stream_gridpool_orders(set_up.gridpool_id, order_states=order_states)
+    set_up.client.gridpool_orders_stream(set_up.gridpool_id, order_states=order_states)
     await asyncio.sleep(0)
 
     set_up.mock_stub.ReceiveGridpoolOrdersStream.assert_called_once()
@@ -161,7 +161,7 @@ async def test_stream_gridpool_trades(
     set_up: SetupParams,
 ) -> None:
     """Test the method streaming gridpool trades."""
-    set_up.client.stream_gridpool_trades(
+    set_up.client.gridpool_trades_stream(
         gridpool_id=set_up.gridpool_id, market_side=set_up.side
     )
     await asyncio.sleep(0)
@@ -179,7 +179,7 @@ async def test_stream_public_trades(
     # Fields to filter for
     trade_states = [TradeState.ACTIVE]
 
-    set_up.client.stream_public_trades(states=trade_states)
+    set_up.client.public_trades_stream(states=trade_states)
     await asyncio.sleep(0)
 
     set_up.mock_stub.ReceivePublicTradesStream.assert_called_once()


### PR DESCRIPTION
This makes it easier to close the streamers when they are no longer
needed.

Also rename the methods from `stream_*` to `*_stream`.