### PR TITLE
Limiting allowed range of trading API versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "frequenz-channels >= 1.6.1, < 2",
   "frequenz-client-base >= 0.9.0, < 0.10.0",
   "frequenz-client-common >= 0.1.0, < 0.3.0",
-  "frequenz-api-electricity-trading >= 0.2.4, < 1",
+  "frequenz-api-electricity-trading >= 0.2.4, < 0.5",
   "protobuf >= 5.28.0, < 6",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
The latest v0.5.0 comes with a breaking change, so limiting the version range.