### PR TITLE
Update release notes after creating tag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,8 +6,6 @@
 
 ## Upgrading
 
-* Updated frequenz-client-common version range to >=0.1.0, <0.4.0
-* Upgraded grpcio to >=1.68.1, <2 and protobuf to >=5.29.2, <6 to resolve compatibility issues 
 * Unify Public Trades streaming and listing (to align with the proto changes in v0.5.0)
     * Removed `list_public_trades`
     * Replaced `public_trades_stream` with `receive_public_trades`


### PR DESCRIPTION
Earlier commit before breaking change was tagged as v0.7.0.