### PR TITLE
Add HMAC capabilities

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 
 - Updated to `v0.8.0` of the Electricity Trading API.
 - Updated to `v0.11.0` of the base client library.
+- Added HMAC capabilities
 
 ## Bug Fixes
 

--- a/src/frequenz/client/electricity_trading/_client.py
+++ b/src/frequenz/client/electricity_trading/_client.py
@@ -161,10 +161,14 @@ def dt_to_pb_timestamp_utc(dt: datetime) -> Timestamp:
 class Client(BaseApiClient[ElectricityTradingServiceStub]):
     """Electricity trading client."""
 
-    _instances: dict[tuple[str, str | None], "Client"] = {}
+    _instances: dict[tuple[str, str | None, str | None], "Client"] = {}
 
     def __new__(
-        cls, server_url: str, connect: bool = True, auth_key: str | None = None
+        cls,
+        server_url: str,
+        connect: bool = True,
+        auth_key: str | None = None,
+        sign_secret: str | None = None,
     ) -> "Client":
         """
         Create a new instance of the client or return an existing one if it already exists.
@@ -173,11 +177,12 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
             server_url: The URL of the Electricity Trading service.
             connect: Whether to connect to the server immediately.
             auth_key: The API key for the authorization.
+            sign_secret: The cryptographic secret to use for HMAC generation.
 
         Returns:
             The client instance.
         """
-        key = (server_url, auth_key)
+        key = (server_url, auth_key, sign_secret)
 
         # Check if an instance already exists for this key
         if key not in cls._instances:
@@ -188,7 +193,11 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
         return cls._instances[key]
 
     def __init__(
-        self, server_url: str, connect: bool = True, auth_key: str | None = None
+        self,
+        server_url: str,
+        connect: bool = True,
+        auth_key: str | None = None,
+        sign_secret: str | None = None,
     ) -> None:
         """Initialize the client.
 
@@ -196,6 +205,7 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
             server_url: The URL of the Electricity Trading service.
             connect: Whether to connect to the server immediately.
             auth_key: The API key for the authorization.
+            sign_secret: The cryptographic secret to use for HMAC generation.
         """
         if not hasattr(
             self, "_initialized"
@@ -204,6 +214,8 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                 server_url,
                 connect=connect,
                 create_stub=ElectricityTradingServiceStub,
+                auth_key=auth_key,
+                sign_secret=sign_secret,
             )
             self._initialized = True
 
@@ -235,8 +247,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                 list[PublicOrder],
             ],
         ] = {}
-
-        self._metadata = (("key", auth_key),) if auth_key else ()
 
     @property
     def stub(self) -> electricity_trading_pb2_grpc.ElectricityTradingServiceAsyncStub:
@@ -311,7 +321,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                             gridpool_id=gridpool_id,
                             filter=gridpool_order_filter.to_pb(),
                         ),
-                        metadata=self._metadata,
                     ),
                     lambda response: OrderDetail.from_pb(response.order_detail),
                 )
@@ -376,7 +385,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                             gridpool_id=gridpool_id,
                             filter=gridpool_trade_filter.to_pb(),
                         ),
-                        metadata=self._metadata,
                     ),
                     lambda response: Trade.from_pb(response.trade),
                 )
@@ -549,7 +557,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                     electricity_trading_pb2.CreateGridpoolOrderRequest(
                         gridpool_id=gridpool_id, order=order.to_pb()
                     ),
-                    metadata=self._metadata,
                     timeout=timeout,
                 ),
             )
@@ -666,7 +673,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                         update_order_fields=update_order_fields.to_pb(),
                         update_mask=update_mask,
                     ),
-                    metadata=self._metadata,
                     timeout=timeout,
                 ),
             )
@@ -705,7 +711,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                     electricity_trading_pb2.CancelGridpoolOrderRequest(
                         gridpool_id=gridpool_id, order_id=order_id
                     ),
-                    metadata=self._metadata,
                     timeout=timeout,
                 ),
             )
@@ -741,7 +746,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                     electricity_trading_pb2.CancelAllGridpoolOrdersRequest(
                         gridpool_id=gridpool_id
                     ),
-                    metadata=self._metadata,
                     timeout=timeout,
                 ),
             )
@@ -782,7 +786,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                     electricity_trading_pb2.GetGridpoolOrderRequest(
                         gridpool_id=gridpool_id, order_id=order_id
                     ),
-                    metadata=self._metadata,
                     timeout=timeout,
                 ),
             )
@@ -848,7 +851,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                     grpc_call_with_timeout(
                         self.stub.ListGridpoolOrders,
                         request,
-                        metadata=self._metadata,
                         timeout=timeout,
                     ),
                 )
@@ -926,7 +928,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                     grpc_call_with_timeout(
                         self.stub.ListGridpoolTrades,
                         request,
-                        metadata=self._metadata,
                         timeout=timeout,
                     ),
                 )
@@ -1010,7 +1011,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                                     dt_to_pb_timestamp(end_time) if end_time else None
                                 ),
                             ),
-                            metadata=self._metadata,
                         ),
                         lambda response: PublicTrade.from_pb(response.public_trade),
                     )
@@ -1071,7 +1071,6 @@ class Client(BaseApiClient[ElectricityTradingServiceStub]):
                                 start_time=start_time_utc,
                                 end_time=end_time_utc,
                             ),
-                            metadata=self._metadata,
                         ),
                         lambda response: [
                             PublicOrder.from_pb(public_order)

--- a/src/frequenz/client/electricity_trading/cli/__main__.py
+++ b/src/frequenz/client/electricity_trading/cli/__main__.py
@@ -46,48 +46,88 @@ def cli() -> None:
 
 @cli.command()
 @click.option("--url", required=True, type=str)
-@click.option("--key", required=True, type=str)
+@click.option("--auth_key", required=True, type=str)
 @click.option("--delivery-start", default=None, type=iso)
 @click.option("--start", default=None, type=iso)
 @click.option("--end", default=None, type=iso)
-def receive_public_trades(
-    url: str, key: str, *, start: datetime, end: datetime, delivery_start: datetime
+@click.option("--sign_secret", default=None, type=str)
+def receive_public_trades(  # pylint: disable=too-many-arguments
+    url: str,
+    auth_key: str,
+    *,
+    start: datetime,
+    end: datetime,
+    delivery_start: datetime,
+    sign_secret: str | None = None,
 ) -> None:
     """List and/or stream public trades."""
     asyncio.run(
         run_receive_public_trades(
-            url=url, key=key, delivery_start=delivery_start, start=start, end=end
+            url=url,
+            auth_key=auth_key,
+            delivery_start=delivery_start,
+            start=start,
+            end=end,
+            sign_secret=sign_secret,
         )
     )
 
 
 @cli.command()
 @click.option("--url", required=True, type=str)
-@click.option("--key", required=True, type=str)
+@click.option("--auth_key", required=True, type=str)
 @click.option("--gid", required=True, type=int)
 @click.option("--start", default=None, type=iso)
-def receive_gridpool_trades(url: str, key: str, gid: int, *, start: datetime) -> None:
+@click.option("--sign_secret", default=None, type=str)
+def receive_gridpool_trades(
+    url: str,
+    auth_key: str,
+    gid: int,
+    *,
+    start: datetime,
+    sign_secret: str | None = None,
+) -> None:
     """List and/or stream gridpool trades."""
     asyncio.run(
-        run_list_gridpool_trades(url=url, key=key, gid=gid, delivery_start=start)
+        run_list_gridpool_trades(
+            url=url,
+            auth_key=auth_key,
+            gid=gid,
+            delivery_start=start,
+            sign_secret=sign_secret,
+        )
     )
 
 
 @cli.command()
 @click.option("--url", required=True, type=str)
-@click.option("--key", required=True, type=str)
+@click.option("--auth_key", required=True, type=str)
 @click.option("--start", default=None, type=iso)
 @click.option("--gid", required=True, type=int)
-def receive_gridpool_orders(url: str, key: str, *, start: datetime, gid: int) -> None:
+@click.option("--sign_secret", default=None, type=str)
+def receive_gridpool_orders(
+    url: str,
+    auth_key: str,
+    *,
+    start: datetime,
+    gid: int,
+    sign_secret: str | None = None,
+) -> None:
     """List and/or stream gridpool orders."""
     asyncio.run(
-        run_list_gridpool_orders(url=url, key=key, delivery_start=start, gid=gid)
+        run_list_gridpool_orders(
+            url=url,
+            auth_key=auth_key,
+            delivery_start=start,
+            gid=gid,
+            sign_secret=sign_secret,
+        )
     )
 
 
 @cli.command()
 @click.option("--url", required=True, type=str)
-@click.option("--key", required=True, type=str)
+@click.option("--auth_key", required=True, type=str)
 @click.option("--start", required=True, type=iso)
 @click.option("--gid", required=True, type=int)
 @click.option("--quantity", required=True, type=str)
@@ -95,10 +135,11 @@ def receive_gridpool_orders(url: str, key: str, *, start: datetime, gid: int) ->
 @click.option("--area", required=True, type=str)
 @click.option("--currency", default="EUR", type=str)
 @click.option("--duration", default=900, type=int)
+@click.option("--sign_secret", default=None, type=str)
 def create_order(
     # pylint: disable=too-many-arguments
     url: str,
-    key: str,
+    auth_key: str,
     *,
     start: datetime,
     gid: int,
@@ -107,6 +148,7 @@ def create_order(
     area: str,
     currency: str,
     duration: int,
+    sign_secret: str | None = None,
 ) -> None:
     """Create an order.
 
@@ -118,7 +160,7 @@ def create_order(
     asyncio.run(
         run_create_order(
             url=url,
-            key=key,
+            auth_key=auth_key,
             delivery_start=start,
             gid=gid,
             quantity_mw=quantity,
@@ -126,27 +168,50 @@ def create_order(
             delivery_area=area,
             currency=currency,
             duration=timedelta(seconds=duration),
+            sign_secret=sign_secret,
         )
     )
 
 
 @cli.command()
 @click.option("--url", required=True, type=str)
-@click.option("--key", required=True, type=str)
+@click.option("--auth_key", required=True, type=str)
 @click.option("--gid", required=True, type=int)
 @click.option("--order", required=True, type=int)
-def cancel_order(url: str, key: str, gid: int, order: int) -> None:
+@click.option("--sign_secret", default=None, type=str)
+def cancel_order(
+    url: str, auth_key: str, gid: int, order: int, sign_secret: str | None = None
+) -> None:
     """Cancel an order."""
-    asyncio.run(run_cancel_order(url=url, key=key, gridpool_id=gid, order_id=order))
+    asyncio.run(
+        run_cancel_order(
+            url=url,
+            auth_key=auth_key,
+            gridpool_id=gid,
+            order_id=order,
+            sign_secret=sign_secret,
+        )
+    )
 
 
 @cli.command()
 @click.option("--url", required=True, type=str)
-@click.option("--key", required=True, type=str)
+@click.option("--auth_key", required=True, type=str)
 @click.option("--gid", required=True, type=int)
-def cancel_all_orders(url: str, key: str, gid: int) -> None:
+@click.option("--sign_secret", default=None, type=str)
+def cancel_all_orders(
+    url: str, auth_key: str, gid: int, sign_secret: str | None = None
+) -> None:
     """Cancel all orders for a gridpool ID."""
-    asyncio.run(run_cancel_order(url=url, key=key, gridpool_id=gid, order_id=None))
+    asyncio.run(
+        run_cancel_order(
+            url=url,
+            auth_key=auth_key,
+            gridpool_id=gid,
+            order_id=None,
+            sign_secret=sign_secret,
+        )
+    )
 
 
 @cli.command()

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -41,24 +41,26 @@ def check_delivery_start(
         raise ValueError("Delivery period must be a multiple of `duration`.")
 
 
-async def receive_public_trades(
+async def receive_public_trades(  # pylint: disable=too-many-arguments
     url: str,
-    key: str,
+    auth_key: str,
     *,
     delivery_start: datetime | None = None,
     start: datetime | None = None,
     end: datetime | None = None,
+    sign_secret: str | None = None,
 ) -> None:
     """List trades and stream new public trades.
 
     Args:
         url: URL of the trading API.
-        key: API key.
+        auth_key: API key.
         delivery_start: Start of the delivery period or None.
         start: First execution time to list trades from.
         end: Last execution time to list trades until.
+        sign_secret: The cryptographic secret to use for HMAC generation.
     """
-    client = Client(server_url=url, auth_key=key)
+    client = Client(server_url=url, auth_key=auth_key, sign_secret=sign_secret)
 
     print_public_trade_header()
 
@@ -80,7 +82,12 @@ async def receive_public_trades(
 
 
 async def list_gridpool_trades(
-    url: str, key: str, gid: int, *, delivery_start: datetime
+    url: str,
+    auth_key: str,
+    gid: int,
+    *,
+    delivery_start: datetime,
+    sign_secret: str | None = None,
 ) -> None:
     """List gridpool trades and stream new gridpool trades.
 
@@ -88,11 +95,12 @@ async def list_gridpool_trades(
 
     Args:
         url: URL of the trading API.
-        key: API key.
+        auth_key: API key.
         gid: Gridpool ID.
         delivery_start: Start of the delivery period or None.
+        sign_secret: The cryptographic secret to use for HMAC generation.
     """
-    client = Client(server_url=url, auth_key=key)
+    client = Client(server_url=url, auth_key=auth_key, sign_secret=sign_secret)
 
     print_trade_header()
 
@@ -120,7 +128,12 @@ async def list_gridpool_trades(
 
 
 async def list_gridpool_orders(
-    url: str, key: str, *, delivery_start: datetime, gid: int
+    url: str,
+    auth_key: str,
+    *,
+    delivery_start: datetime,
+    gid: int,
+    sign_secret: str | None = None,
 ) -> None:
     """List orders and stream new gridpool orders.
 
@@ -133,11 +146,12 @@ async def list_gridpool_orders(
 
     Args:
         url: URL of the trading API.
-        key: API key.
+        auth_key: API key.
         delivery_start: Start of the delivery period or None.
         gid: Gridpool ID.
+        sign_secret: The cryptographic secret to use for HMAC generation.
     """
-    client = Client(server_url=url, auth_key=key)
+    client = Client(server_url=url, auth_key=auth_key, sign_secret=sign_secret)
 
     print_order_header()
 
@@ -167,7 +181,7 @@ async def list_gridpool_orders(
 # pylint: disable=too-many-arguments
 async def create_order(
     url: str,
-    key: str,
+    auth_key: str,
     *,
     gid: int,
     delivery_start: datetime,
@@ -176,6 +190,7 @@ async def create_order(
     quantity_mw: str,
     currency: str,
     duration: timedelta,
+    sign_secret: str | None = None,
 ) -> None:
     """Create a limit order for a given price and quantity (in MW).
 
@@ -185,7 +200,7 @@ async def create_order(
 
     Args:
         url: URL of the trading API.
-        key: API key.
+        auth_key: API key.
         gid: Gridpool ID.
         delivery_start: Start of the delivery period.
         delivery_area: Delivery area code.
@@ -193,8 +208,9 @@ async def create_order(
         quantity_mw: Quantity in MW, positive for buy orders and negative for sell orders.
         currency: Currency of the price.
         duration: Duration of the delivery period.
+        sign_secret: The cryptographic secret to use for HMAC generation.
     """
-    client = Client(server_url=url, auth_key=key)
+    client = Client(server_url=url, auth_key=auth_key, sign_secret=sign_secret)
 
     side = MarketSide.SELL if quantity_mw[0] == "-" else MarketSide.BUY
     quantity = Power(mw=Decimal(quantity_mw.lstrip("-")))
@@ -222,7 +238,12 @@ async def create_order(
 
 
 async def cancel_order(
-    url: str, key: str, *, gridpool_id: int, order_id: int | None
+    url: str,
+    auth_key: str,
+    *,
+    gridpool_id: int,
+    order_id: int | None,
+    sign_secret: str | None = None,
 ) -> None:
     """Cancel an order by order ID.
 
@@ -230,11 +251,12 @@ async def cancel_order(
 
     Args:
         url: URL of the trading API.
-        key: API key.
+        auth_key: API key.
         gridpool_id: Gridpool ID.
         order_id: Order ID to cancel or None to cancel all orders.
+        sign_secret: The cryptographic secret to use for HMAC generation.
     """
-    client = Client(server_url=url, auth_key=key)
+    client = Client(server_url=url, auth_key=auth_key, sign_secret=sign_secret)
     if order_id is None:
         await client.cancel_all_gridpool_orders(gridpool_id)
     else:


### PR DESCRIPTION
This adds HMAC capabilities by allowing to provide a signature secret. Additionally removes the old way of adding the API key to the metadata.