### PR TITLE
Add is_valid check to OrderDetail

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* Add check to validate order details.
 
 ## Bug Fixes
 

--- a/src/frequenz/client/electricity_trading/_types.py
+++ b/src/frequenz/client/electricity_trading/_types.py
@@ -1380,6 +1380,23 @@ class OrderDetail:
 
         return od
 
+    @property
+    def is_valid(self) -> bool:
+        """Check if the order detail is valid.
+
+        Returns:
+            True if the order detail is valid, False otherwise.
+        """
+        # Only cancelled orders are allowed to have missing price or quantity
+        if self.state_detail.state == OrderState.CANCELED:
+            return True
+
+        return not (
+            self.order.price.amount.is_nan()
+            or self.order.price.currency == Currency.UNSPECIFIED
+            or self.order.quantity.mw.is_nan()
+        )
+
     def to_pb(self) -> electricity_trading_pb2.OrderDetail:
         """Convert an OrderDetail object to protobuf OrderDetail.
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -580,18 +580,26 @@ def test_order_detail_from_pb_missing_fields() -> None:
     # Missing price
     od_pb1 = electricity_trading_pb2.OrderDetail()
     od_pb1.CopyFrom(ORDER_DETAIL_PB)
+    assert OrderDetail.from_pb(od_pb1).is_valid
     od_pb1.order.ClearField("price")
     OrderDetail.from_pb(od_pb1)
+    # Not allowed for active orders
+    assert not OrderDetail.from_pb(od_pb1).is_valid
     od_pb1.state_detail.state = electricity_trading_pb2.OrderState.ORDER_STATE_CANCELED
     OrderDetail.from_pb(od_pb1)
+    # But allowed for canceled orders
+    assert OrderDetail.from_pb(od_pb1).is_valid
 
     # Missing quantity (same logic as above)
     od_pb2 = electricity_trading_pb2.OrderDetail()
     od_pb2.CopyFrom(ORDER_DETAIL_PB)
+    assert OrderDetail.from_pb(od_pb2).is_valid
     od_pb2.order.ClearField("quantity")
     OrderDetail.from_pb(od_pb2)
+    assert not OrderDetail.from_pb(od_pb2).is_valid
     od_pb2.state_detail.state = electricity_trading_pb2.OrderState.ORDER_STATE_CANCELED
     OrderDetail.from_pb(od_pb2)
+    assert OrderDetail.from_pb(od_pb2).is_valid
 
 
 def test_order_detail_no_timezone_error() -> None:


### PR DESCRIPTION
Can be used by the user to check the validity of an order, which is
currently defined as any order with a valid price and quantity, or in
cancelled state.