### PR TITLE
Support listing gridpool orders without price or quantity

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@
 
 * Widen the version range of api-common to also allow v0.8.x.
 * Restrict entsoe client dependency version range up to v0.7.x.
+* Listing gridpool orders that do not contain a price or quantity no longer raises an exception. Users must validate orders themselves.
 
 ## New Features
 

--- a/src/frequenz/client/electricity_trading/_types.py
+++ b/src/frequenz/client/electricity_trading/_types.py
@@ -1316,9 +1316,6 @@ class OrderDetail:
 
         Returns:
             OrderDetail object corresponding to the protobuf message.
-
-        Raises:
-            ValueError: If the order price and quantity are not specified for a non-canceled order.
         """
         od = cls(
             order_id=order_detail.order_id,
@@ -1331,17 +1328,6 @@ class OrderDetail:
                 tzinfo=timezone.utc
             ),
         )
-
-        # Only cancelled orders are allowed to have missing price or quantity
-        missing_price_or_quantity = (
-            od.order.price.amount.is_nan()
-            or od.order.price.currency == Currency.UNSPECIFIED
-            or od.order.quantity.mw.is_nan()
-        )
-        if missing_price_or_quantity and od.state_detail.state != OrderState.CANCELED:
-            raise ValueError(
-                f"Price and quantity must be specified for a non-canceled order (`{od}`)."
-            )
 
         return od
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -551,14 +551,12 @@ def test_order_detail_from_pb() -> None:
 
 def test_order_detail_from_pb_missing_fields() -> None:
     """Test the client order detail type conversion from protobuf with missing fields."""
+    # Previously missing price or quantity raised an error, now it is handled gracefully.
     # Missing price
     od_pb1 = electricity_trading_pb2.OrderDetail()
     od_pb1.CopyFrom(ORDER_DETAIL_PB)
     od_pb1.order.ClearField("price")
-    # Not allowed for active orders
-    with pytest.raises(ValueError):
-        OrderDetail.from_pb(od_pb1)
-    # But allowed for canceled orders
+    OrderDetail.from_pb(od_pb1)
     od_pb1.state_detail.state = electricity_trading_pb2.OrderState.ORDER_STATE_CANCELED
     OrderDetail.from_pb(od_pb1)
 
@@ -566,8 +564,7 @@ def test_order_detail_from_pb_missing_fields() -> None:
     od_pb2 = electricity_trading_pb2.OrderDetail()
     od_pb2.CopyFrom(ORDER_DETAIL_PB)
     od_pb2.order.ClearField("quantity")
-    with pytest.raises(ValueError):
-        OrderDetail.from_pb(od_pb2)
+    OrderDetail.from_pb(od_pb2)
     od_pb2.state_detail.state = electricity_trading_pb2.OrderState.ORDER_STATE_CANCELED
     OrderDetail.from_pb(od_pb2)
 


### PR DESCRIPTION
When listing, gridpool orders that do not contain a price or quantity were previously considered invalid and raised an exception. Since this prevented listing any set of orders where at least one order was considered invalid, this has been changed and users have to validate orders themselves.