### PR TITLE
Restrict entsoe dependency version range

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,8 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+* Widen the version range of api-common to also allow v0.8.x.
+* Restrict entsoe client dependency version range up to v0.7.x.
 
 ## New Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ requires-python = ">= 3.11, < 4"
 # TODO(cookiecutter): Remove and add more dependencies if appropriate
 dependencies = [
   "click >= 8.1.8, < 9",
-  # Versions beyond 0.7.2 fail mypy checks
-  "entsoe-py >= 0.6.16, < 0.7.2",
+  "entsoe-py >= 0.6.16, < 0.8.0",
   "frequenz-api-common >= 0.6.5, < 0.9.0",
   "grpcio >= 1.72.1, < 2",
   "frequenz-channels >= 1.6.1, < 2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ requires-python = ">= 3.11, < 4"
 # TODO(cookiecutter): Remove and add more dependencies if appropriate
 dependencies = [
   "click >= 8.1.8, < 9",
-  "entsoe-py >= 0.6.16, < 1",
+  # Versions beyond 0.7.2 fail mypy checks
+  "entsoe-py >= 0.6.16, < 0.7.2",
   "frequenz-api-common >= 0.6.5, < 0.9.0",
   "grpcio >= 1.72.1, < 2",
   "frequenz-channels >= 1.6.1, < 2",

--- a/src/frequenz/client/electricity_trading/cli/day_ahead.py
+++ b/src/frequenz/client/electricity_trading/cli/day_ahead.py
@@ -6,7 +6,7 @@
 from datetime import datetime
 
 import pandas as pd
-from entsoe import EntsoePandasClient
+from entsoe import EntsoePandasClient  # type: ignore[attr-defined]
 
 
 def list_day_ahead_prices(


### PR DESCRIPTION
And fix a new mypy failure arising in newer versions of the entsoe client. The version range is restricted to better control upcoming, potentially breaking changes.