### PR TITLE
Fix `tests` namespace pollution from entsoe and remove tests/init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ requires-python = ">= 3.11, < 4"
 # TODO(cookiecutter): Remove and add more dependencies if appropriate
 dependencies = [
   "click >= 8.1.8, < 9",
-  "entsoe-py >= 0.6.16, < 0.8.0",
+  # Stick to a version without a polluting `tests` package: https://github.com/EnergieID/entsoe-py/pull/447
+  "entsoe-py >= 0.6.16, < 0.7.1",
   "frequenz-api-common >= 0.6.5, < 0.9.0",
   "grpcio >= 1.72.1, < 2",
   "frequenz-channels >= 1.6.1, < 2",

--- a/src/frequenz/client/electricity_trading/cli/day_ahead.py
+++ b/src/frequenz/client/electricity_trading/cli/day_ahead.py
@@ -6,7 +6,7 @@
 from datetime import datetime
 
 import pandas as pd
-from entsoe import EntsoePandasClient  # type: ignore[attr-defined]
+from entsoe import EntsoePandasClient
 
 
 def list_day_ahead_prices(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-# License: Proprietary
-# Copyright © 2025 Frequenz Energy-as-a-Service GmbH
-
-"""Tests for Electricity Trading API client."""


### PR DESCRIPTION
See https://github.com/EnergieID/entsoe-py/pull/447 for details.
Example of the problem: 

```
nox > mypy docs noxfile.py tests
Success: no issues found in 8 source files
nox > pylint src docs noxfile.py tests
************* Module tests
tests/__init__.py:1:0: F0010: error while code parsing: Unable to load file tests/__init__.py:
[Errno 2] No such file or directory: 'tests/__init__.py' (parse-error)
```

THis also removes the init file, as described in https://github.com/frequenz-io/rnd/issues/170