### PR TITLE
[DONT-MERGE] Change all client types to be `frozen` datatypes

### DIFF
--- a/src/frequenz/client/electricity_trading/_types.py
+++ b/src/frequenz/client/electricity_trading/_types.py
@@ -313,6 +313,34 @@ class DeliveryDuration(enum.Enum):
     """1-hour contract duration."""
 
     @classmethod
+    def from_timedelta(cls, duration: timedelta) -> Self:
+        """Convert a timedelta to a DeliveryDuration enum.
+
+        Args:
+            duration: The duration as a timedelta.
+
+        Returns:
+            The corresponding DeliveryDuration enum value.
+
+        Raises:
+            ValueError: If the duration is not one of the supported values.
+        """
+        minutes = duration.total_seconds() / 60
+        match minutes:
+            case 5:
+                return DeliveryDuration.MINUTES_5
+            case 15:
+                return DeliveryDuration.MINUTES_15
+            case 30:
+                return DeliveryDuration.MINUTES_30
+            case 60:
+                return DeliveryDuration.MINUTES_60
+            case _:
+                raise ValueError(
+                    "Invalid duration value. Duration must be 5, 15, 30, or 60 minutes."
+                )
+
+    @classmethod
     @from_pb
     def from_pb(
         cls, delivery_duration: delivery_duration_pb2.DeliveryDuration.ValueType

--- a/src/frequenz/client/electricity_trading/_types.py
+++ b/src/frequenz/client/electricity_trading/_types.py
@@ -386,54 +386,6 @@ class DeliveryPeriod:
     duration: DeliveryDuration
     """The length of the delivery period."""
 
-    def __init__(
-        self,
-        start: datetime,
-        duration: timedelta,
-    ) -> None:
-        """
-        Initialize the DeliveryPeriod object.
-
-        Args:
-            start: Start UTC timestamp represents the beginning of the delivery period.
-            duration: The length of the delivery period.
-
-        Raises:
-            ValueError: If the start timestamp does not have a timezone.
-                        or if the duration is not 5, 15, 30, or 60 minutes.
-        """
-        if start.tzinfo is None:
-            raise ValueError("Start timestamp must have a timezone.")
-        if start.tzinfo != timezone.utc:
-            _logger.warning(
-                "Start timestamp is not in UTC timezone. Converting to UTC."
-            )
-            start = start.astimezone(timezone.utc)
-        self.start = start
-
-        minutes = duration.total_seconds() / 60
-        match minutes:
-            case 5:
-                self.duration = DeliveryDuration.MINUTES_5
-            case 15:
-                self.duration = DeliveryDuration.MINUTES_15
-            case 30:
-                self.duration = DeliveryDuration.MINUTES_30
-            case 60:
-                self.duration = DeliveryDuration.MINUTES_60
-            case _:
-                raise ValueError(
-                    "Invalid duration value. Duration must be 5, 15, 30, or 60 minutes."
-                )
-
-    def __hash__(self) -> int:
-        """
-        Create hash of the DeliveryPeriod object.
-
-        Returns:
-            Hash of the DeliveryPeriod object.
-        """
-        return hash((self.start, self.duration))
 
     def __eq__(
         self,
@@ -481,27 +433,10 @@ class DeliveryPeriod:
 
         Returns:
             DeliveryPeriod object corresponding to the protobuf message.
-
-        Raises:
-            ValueError: If the duration is not 5, 15, 30, or 60 minutes.
         """
         start = delivery_period.start.ToDatetime(tzinfo=timezone.utc)
         delivery_duration_enum = DeliveryDuration.from_pb(delivery_period.duration)
-
-        match delivery_duration_enum:
-            case DeliveryDuration.MINUTES_5:
-                duration = timedelta(minutes=5)
-            case DeliveryDuration.MINUTES_15:
-                duration = timedelta(minutes=15)
-            case DeliveryDuration.MINUTES_30:
-                duration = timedelta(minutes=30)
-            case DeliveryDuration.MINUTES_60:
-                duration = timedelta(minutes=60)
-            case _:
-                raise ValueError(
-                    "Invalid duration value. Duration must be 5, 15, 30, or 60 minutes."
-                )
-        return cls(start=start, duration=duration)
+        return cls(start=start, duration=delivery_duration_enum)
 
     def to_pb(self) -> delivery_duration_pb2.DeliveryPeriod:
         """Convert a DeliveryPeriod object to protobuf DeliveryPeriod.

--- a/src/frequenz/client/electricity_trading/_types.py
+++ b/src/frequenz/client/electricity_trading/_types.py
@@ -386,6 +386,10 @@ class DeliveryPeriod:
     duration: DeliveryDuration
     """The length of the delivery period."""
 
+    def __post_init__(self) -> None:
+        """Validate that the start timestamp is in UTC."""
+        if self.start.tzinfo is None or self.start.tzinfo != timezone.utc:
+            raise ValueError("Start timestamp must be in UTC timezone.")
 
     def __eq__(
         self,
@@ -951,11 +955,11 @@ class Order:  # pylint: disable=too-many-instance-attributes
     def __post_init__(self) -> None:
         """Post initialization checks to ensure that all datetimes are UTC."""
         if self.valid_until is not None:
-            if self.valid_until.tzinfo is None:
+            if (
+                self.valid_until.tzinfo is None
+                or self.valid_until.tzinfo != timezone.utc
+            ):
                 raise ValueError("Valid until must be a UTC datetime.")
-            if self.valid_until.tzinfo != timezone.utc:
-                _logger.warning("Valid until is not a UTC datetime. Converting to UTC.")
-                self.valid_until = self.valid_until.astimezone(timezone.utc)
 
     @classmethod
     @from_pb
@@ -1124,11 +1128,11 @@ class Trade:  # pylint: disable=too-many-instance-attributes
 
     def __post_init__(self) -> None:
         """Post initialization checks to ensure that all datetimes are UTC."""
-        if self.execution_time.tzinfo is None:
-            raise ValueError("Execution time must have timezone information")
-        if self.execution_time.tzinfo != timezone.utc:
-            _logger.warning("Execution timenis not in UTC timezone. Converting to UTC.")
-            self.execution_time = self.execution_time.astimezone(timezone.utc)
+        if (
+            self.execution_time.tzinfo is None
+            or self.execution_time.tzinfo != timezone.utc
+        ):
+            raise ValueError("Execution time must be a UTC datetime.")
 
     @classmethod
     @from_pb
@@ -1255,19 +1259,14 @@ class OrderDetail:
             ValueError: If create_time or modification_time do not have timezone information.
 
         """
-        if self.create_time.tzinfo is None:
-            raise ValueError("Create time must have timezone information")
-        if self.create_time.tzinfo != timezone.utc:
-            _logger.warning("Create time is not in UTC timezone. Converting to UTC.")
-            self.create_time = self.create_time.astimezone(timezone.utc)
+        if self.create_time.tzinfo is None or self.create_time.tzinfo != timezone.utc:
+            raise ValueError("Create time must be a UTC datetime.")
 
-        if self.modification_time.tzinfo is None:
-            raise ValueError("Modification time must have timezone information")
-        if self.modification_time.tzinfo != timezone.utc:
-            _logger.warning(
-                "Modification time is not in UTC timezone. Converting to UTC."
-            )
-            self.modification_time = self.modification_time.astimezone(timezone.utc)
+        if (
+            self.modification_time.tzinfo is None
+            or self.modification_time.tzinfo != timezone.utc
+        ):
+            raise ValueError("Modification time must be a UTC datetime.")
 
     @classmethod
     @from_pb
@@ -1346,11 +1345,11 @@ class PublicTrade:  # pylint: disable=too-many-instance-attributes
 
     def __post_init__(self) -> None:
         """Post initialization checks to ensure that all datetimes are UTC."""
-        if self.execution_time.tzinfo is None:
-            raise ValueError("Execution time must have timezone information")
-        if self.execution_time.tzinfo != timezone.utc:
-            _logger.warning("Execution time is not in UTC timezone. Converting to UTC.")
-            self.execution_time = self.execution_time.astimezone(timezone.utc)
+        if (
+            self.execution_time.tzinfo is None
+            or self.execution_time.tzinfo != timezone.utc
+        ):
+            raise ValueError("Execution time must be a UTC datetime.")
 
     @classmethod
     @from_pb
@@ -1796,12 +1795,10 @@ class UpdateOrder:  # pylint: disable=too-many-instance-attributes
 
     def __post_init__(self) -> None:
         """Post initialization checks to ensure that all datetimes are UTC."""
-        if self.valid_until is not None:
-            if self.valid_until.tzinfo is None:
-                raise ValueError("Valid until must be a UTC datetime.")
-            if self.valid_until.tzinfo != timezone.utc:
-                _logger.warning("Valid until is not a UTC datetime. Converting to UTC.")
-                self.valid_until = self.valid_until.astimezone(timezone.utc)
+        if self.valid_until is not None and (
+            self.valid_until.tzinfo is None or self.valid_until.tzinfo != timezone.utc
+        ):
+            raise ValueError("Valid until must be a UTC datetime.")
 
     @classmethod
     @from_pb
@@ -1928,18 +1925,6 @@ class PublicOrder:  # pylint: disable=too-many-instance-attributes
 
     update_time: datetime
     """UTC Timestamp of the last update to the order."""
-
-    def __post_init__(self) -> None:
-        """Post initialization checks to ensure that all datetimes are UTC."""
-        if self.delivery_period.start.tzinfo is None:
-            raise ValueError("Delivery period start must have timezone information")
-        if self.delivery_period.start.tzinfo != timezone.utc:
-            _logger.warning(
-                "Delivery period start is not in UTC timezone. Converting to UTC."
-            )
-            self.delivery_period.start = self.delivery_period.start.astimezone(
-                timezone.utc
-            )
 
     @classmethod
     @from_pb

--- a/src/frequenz/client/electricity_trading/_types.py
+++ b/src/frequenz/client/electricity_trading/_types.py
@@ -371,6 +371,7 @@ class DeliveryDuration(enum.Enum):
         return delivery_duration_pb2.DeliveryDuration.ValueType(self.value)
 
 
+@dataclass(frozen=True)
 class DeliveryPeriod:
     """
     Time period during which the contract is delivered.
@@ -906,7 +907,7 @@ class MarketActor(enum.Enum):
         return self.value
 
 
-@dataclass()
+@dataclass(frozen=True)
 class Order:  # pylint: disable=too-many-instance-attributes
     """Represents an order in the electricity market."""
 
@@ -1094,7 +1095,7 @@ class Order:  # pylint: disable=too-many-instance-attributes
         )
 
 
-@dataclass()
+@dataclass(frozen=True)
 class Trade:  # pylint: disable=too-many-instance-attributes
     """Represents a private trade in the electricity market."""
 
@@ -1228,7 +1229,7 @@ class StateDetail:
         )
 
 
-@dataclass()
+@dataclass(frozen=True)
 class OrderDetail:
     """
     Represents an order with full details, including its ID, state, and associated UTC timestamps.
@@ -1315,7 +1316,7 @@ class OrderDetail:
         )
 
 
-@dataclass()
+@dataclass(frozen=True)
 class PublicTrade:  # pylint: disable=too-many-instance-attributes
     """Represents a public order in the market."""
 
@@ -1752,7 +1753,7 @@ class PublicTradeFilter:
         )
 
 
-@dataclass()
+@dataclass(frozen=True)
 class UpdateOrder:  # pylint: disable=too-many-instance-attributes
     """
     Represents the order properties that can be updated after an order has been placed.
@@ -1892,7 +1893,7 @@ class UpdateOrder:  # pylint: disable=too-many-instance-attributes
         )
 
 
-@dataclass()
+@dataclass(frozen=True)
 class PublicOrder:  # pylint: disable=too-many-instance-attributes
     """Represents a public order in the market."""
 
@@ -1993,7 +1994,7 @@ class PublicOrder:  # pylint: disable=too-many-instance-attributes
         )
 
 
-@dataclass()
+@dataclass(frozen=True)
 class PublicOrderBookFilter:
     """Parameters for filtering the public orders in the market."""
 

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -13,6 +13,7 @@ from frequenz.client.electricity_trading import (
     Client,
     Currency,
     DeliveryArea,
+    DeliveryDuration,
     DeliveryPeriod,
     EnergyMarketCodeType,
     MarketSide,
@@ -71,7 +72,7 @@ async def receive_public_trades(  # pylint: disable=too-many-arguments
         check_delivery_start(delivery_start)
         delivery_period = DeliveryPeriod(
             start=delivery_start,
-            duration=timedelta(minutes=15),
+            duration=DeliveryDuration.MINUTES_15,
         )
     stream = client.receive_public_trades(
         delivery_period=delivery_period,
@@ -111,7 +112,7 @@ async def receive_public_orders(  # pylint: disable=too-many-arguments
         check_delivery_start(delivery_start)
         delivery_period = DeliveryPeriod(
             start=delivery_start,
-            duration=timedelta(minutes=15),
+            duration=DeliveryDuration.MINUTES_15,
         )
     stream = client.receive_public_order_book(
         delivery_period=delivery_period,
@@ -151,8 +152,7 @@ async def list_gridpool_trades(
     if delivery_start is not None:
         check_delivery_start(delivery_start)
         delivery_period = DeliveryPeriod(
-            start=delivery_start,
-            duration=timedelta(minutes=15),
+            start=delivery_start, duration=DeliveryDuration.MINUTES_15
         )
     lst = client.list_gridpool_trades(gid, delivery_period=delivery_period)
 
@@ -203,7 +203,7 @@ async def list_gridpool_orders(
         check_delivery_start(delivery_start)
         delivery_period = DeliveryPeriod(
             start=delivery_start,
-            duration=timedelta(minutes=15),
+            duration=DeliveryDuration.MINUTES_15,
         )
     lst = client.list_gridpool_orders(gid, delivery_period=delivery_period)
 
@@ -265,7 +265,7 @@ async def create_order(
         ),
         delivery_period=DeliveryPeriod(
             start=delivery_start,
-            duration=duration,
+            duration=DeliveryDuration.from_timedelta(duration),
         ),
         order_type=OrderType.LIMIT,
         side=side,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,7 @@ from frequenz.client.electricity_trading import (
     Client,
     Currency,
     DeliveryArea,
+    DeliveryDuration,
     DeliveryPeriod,
     EnergyMarketCodeType,
     MarketActor,
@@ -80,7 +81,7 @@ def set_up() -> Generator[Any, Any, Any]:
     delivery_area = DeliveryArea(code="DE", code_type=EnergyMarketCodeType.EUROPE_EIC)
     delivery_period = DeliveryPeriod(
         start=delivery_start,
-        duration=timedelta(minutes=15),
+        duration=DeliveryDuration.MINUTES_15,
     )
     order_type = OrderType.LIMIT
     side = MarketSide.BUY
@@ -342,7 +343,7 @@ async def test_list_gridpool_orders(
             Power(mw=Decimal("0.1")),
             DeliveryPeriod(
                 start=(datetime.now(timezone.utc) + timedelta(days=1)),
-                duration=timedelta(hours=1),
+                duration=DeliveryDuration.MINUTES_60,
             ),
             None,
             OrderExecutionOption.AON,  # Using AON here but valid_until is None
@@ -354,7 +355,7 @@ async def test_list_gridpool_orders(
             Power(mw=Decimal("0.1234")),
             DeliveryPeriod(
                 start=(datetime.now(timezone.utc) + timedelta(days=1)),
-                duration=timedelta(hours=1),
+                duration=DeliveryDuration.MINUTES_60,
             ),
             None,
             OrderExecutionOption.AON,
@@ -366,7 +367,7 @@ async def test_list_gridpool_orders(
             Power(mw=Decimal("0.1")),
             DeliveryPeriod(
                 start=(datetime.now(timezone.utc) - timedelta(days=1)),
-                duration=timedelta(hours=1),
+                duration=DeliveryDuration.MINUTES_60,
             ),
             None,
             OrderExecutionOption.AON,
@@ -378,7 +379,7 @@ async def test_list_gridpool_orders(
             Power(mw=Decimal("0.1")),
             DeliveryPeriod(
                 start=(datetime.now(timezone.utc) + timedelta(days=1)),
-                duration=timedelta(hours=1),
+                duration=DeliveryDuration.MINUTES_60,
             ),
             datetime.now(timezone.utc) - timedelta(hours=1),
             OrderExecutionOption.UNSPECIFIED,  # Using an option that allows valid_until
@@ -390,7 +391,7 @@ async def test_list_gridpool_orders(
             Power(mw=Decimal("0.1")),
             DeliveryPeriod(
                 start=(datetime.now(timezone.utc) + timedelta(days=1)),
-                duration=timedelta(hours=1),
+                duration=DeliveryDuration.MINUTES_60,
             ),
             datetime.now(timezone.utc) + timedelta(days=1),
             OrderExecutionOption.AON,  # Invalid case with AON and valid_until set

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -605,25 +605,23 @@ def test_order_detail_no_timezone_error() -> None:
         )
 
 
-def test_order_detail_timezone_converted_to_utc() -> None:
+def test_order_detail_non_utc_timezone() -> None:
     """Test that an order detail with inputs with non-UTC timezone is converted to UTC."""
     start = datetime.now(timezone(timedelta(hours=1)))
-    order_detail = OrderDetail(
-        order_id=1,
-        order=ORDER,
-        state_detail=StateDetail(
-            state=OrderState.ACTIVE,
-            state_reason=StateReason.ADD,
-            market_actor=MarketActor.USER,
-        ),
-        open_quantity=Power(mw=Decimal("5.00")),
-        filled_quantity=Power(mw=Decimal("0.00")),
-        create_time=start,
-        modification_time=start,
-    )
-
-    assert order_detail.create_time.tzinfo == timezone.utc
-    assert order_detail.modification_time.tzinfo == timezone.utc
+    with pytest.raises(ValueError):
+        OrderDetail(
+            order_id=1,
+            order=ORDER,
+            state_detail=StateDetail(
+                state=OrderState.ACTIVE,
+                state_reason=StateReason.ADD,
+                market_actor=MarketActor.USER,
+            ),
+            open_quantity=Power(mw=Decimal("5.00")),
+            filled_quantity=Power(mw=Decimal("0.00")),
+            create_time=start,
+            modification_time=start,
+        )
 
 
 def test_gridpool_order_filter_to_pb() -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -57,7 +57,9 @@ MODIFICATION_TIME = datetime.fromisoformat("2023-01-01T12:00:00+00:00")
 MODIFICATION_TIME_PB = timestamp_pb2.Timestamp(seconds=1672574400)
 ORDER = Order(
     delivery_area=DeliveryArea(code="XYZ", code_type=EnergyMarketCodeType.EUROPE_EIC),
-    delivery_period=DeliveryPeriod(start=START_TIME, duration=timedelta(minutes=15)),
+    delivery_period=DeliveryPeriod(
+        start=START_TIME, duration=DeliveryDuration.MINUTES_15
+    ),
     type=OrderType.LIMIT,
     side=MarketSide.BUY,
     price=Price(amount=Decimal("100.00"), currency=Currency.USD),
@@ -86,7 +88,7 @@ TRADE = Trade(
     side=MarketSide.BUY,
     execution_time=EXECUTION_TIME,
     delivery_area=DeliveryArea(code="XYZ", code_type=EnergyMarketCodeType.EUROPE_EIC),
-    delivery_period=DeliveryPeriod(START_TIME, duration=timedelta(minutes=15)),
+    delivery_period=DeliveryPeriod(START_TIME, duration=DeliveryDuration.MINUTES_15),
     price=Price(amount=Decimal("100.00"), currency=Currency.USD),
     quantity=Power(mw=Decimal("5.00")),
     state=TradeState.ACTIVE,
@@ -147,7 +149,9 @@ PUBLIC_TRADE = PublicTrade(
     sell_delivery_area=DeliveryArea(
         code="ABC", code_type=EnergyMarketCodeType.EUROPE_EIC
     ),
-    delivery_period=DeliveryPeriod(start=START_TIME, duration=timedelta(minutes=15)),
+    delivery_period=DeliveryPeriod(
+        start=START_TIME, duration=DeliveryDuration.MINUTES_15
+    ),
     execution_time=EXECUTION_TIME,
     price=Price(amount=Decimal("100.00"), currency=Currency.USD),
     quantity=Power(mw=Decimal("5.00")),
@@ -178,7 +182,9 @@ PUBLIC_TRADE_PB = electricity_trading_pb2.PublicTrade(
 PUBLIC_ORDER = PublicOrder(
     public_order_id=42,
     delivery_area=DeliveryArea(code="XYZ", code_type=EnergyMarketCodeType.EUROPE_EIC),
-    delivery_period=DeliveryPeriod(start=START_TIME, duration=timedelta(minutes=15)),
+    delivery_period=DeliveryPeriod(
+        start=START_TIME, duration=DeliveryDuration.MINUTES_15
+    ),
     type=OrderType.LIMIT,
     side=MarketSide.BUY,
     price=Price(amount=Decimal("100.00"), currency=Currency.EUR),
@@ -210,7 +216,9 @@ PUBLIC_ORDER_PB = electricity_trading_pb2.PublicOrderBookRecord(
 )
 PUBLIC_ORDER_BOOK_FILTER = PublicOrderBookFilter(
     delivery_area=DeliveryArea(code="XYZ", code_type=EnergyMarketCodeType.EUROPE_EIC),
-    delivery_period=DeliveryPeriod(start=START_TIME, duration=timedelta(minutes=15)),
+    delivery_period=DeliveryPeriod(
+        start=START_TIME, duration=DeliveryDuration.MINUTES_15
+    ),
     side=MarketSide.SELL,
 )
 PUBLIC_ORDER_BOOK_FILTER_PB = electricity_trading_pb2.PublicOrderBookFilter(
@@ -227,7 +235,9 @@ PUBLIC_ORDER_BOOK_FILTER_PB = electricity_trading_pb2.PublicOrderBookFilter(
 GRIDPOOL_ORDER_FILTER = GridpoolOrderFilter(
     order_states=[OrderState.ACTIVE, OrderState.CANCELED],
     side=MarketSide.BUY,
-    delivery_period=DeliveryPeriod(start=START_TIME, duration=timedelta(minutes=15)),
+    delivery_period=DeliveryPeriod(
+        start=START_TIME, duration=DeliveryDuration.MINUTES_15
+    ),
     delivery_area=DeliveryArea(code="XYZ", code_type=EnergyMarketCodeType.EUROPE_EIC),
     tag="test",
 )
@@ -257,7 +267,9 @@ PUBLIC_TRADE_FILTER = PublicTradeFilter(
         code="XYZ", code_type=EnergyMarketCodeType.EUROPE_EIC
     ),
     sell_delivery_area=None,
-    delivery_period=DeliveryPeriod(start=START_TIME, duration=timedelta(minutes=15)),
+    delivery_period=DeliveryPeriod(
+        start=START_TIME, duration=DeliveryDuration.MINUTES_15
+    ),
 )
 PUBLIC_TRADE_FILTER_PB = electricity_trading_pb2.PublicTradeFilter(
     states=[
@@ -429,7 +441,7 @@ def test_delivery_duration_from_pb() -> None:
 def test_delivery_period_to_pb() -> None:
     """Test the client delivery period type conversions to protobuf."""
     assert_conversion_to_pb(
-        original=DeliveryPeriod(start=START_TIME, duration=timedelta(minutes=15)),
+        original=DeliveryPeriod(start=START_TIME, duration=DeliveryDuration.MINUTES_15),
         expected_pb=delivery_duration_pb2.DeliveryPeriod(
             start=START_TIME_PB,
             duration=delivery_duration_pb2.DeliveryDuration.DELIVERY_DURATION_15,
@@ -445,7 +457,7 @@ def test_delivery_period_from_pb() -> None:
             start=START_TIME_PB,
             duration=delivery_duration_pb2.DeliveryDuration.DELIVERY_DURATION_15,
         ),
-        expected=DeliveryPeriod(start=START_TIME, duration=timedelta(minutes=15)),
+        expected=DeliveryPeriod(start=START_TIME, duration=DeliveryDuration.MINUTES_15),
         assert_func=assert_equal,
     )
 
@@ -453,22 +465,28 @@ def test_delivery_period_from_pb() -> None:
 def test_invalid_duration_raises_value_error() -> None:
     """Test that an invalid duration raises a ValueError."""
     with pytest.raises(ValueError):
-        DeliveryPeriod(start=datetime.now(timezone.utc), duration=timedelta(minutes=10))
+        DeliveryPeriod(
+            start=datetime.now(timezone.utc),
+            duration=DeliveryDuration.from_timedelta(timedelta(minutes=10)),
+        )
 
 
 def test_no_timezone_raises_value_error() -> None:
     """Test that a datetime without timezone raises a ValueError."""
     with pytest.raises(ValueError):
-        DeliveryPeriod(start=datetime.now(), duration=timedelta(minutes=5))
+        DeliveryPeriod(
+            start=datetime.now(),
+            duration=DeliveryDuration.MINUTES_5,
+        )
 
 
-def test_invalid_timezone_converted_to_utc() -> None:
+def test_invalid_timezone() -> None:
     """Test that non-UTC timezones are converted to UTC."""
-    start = datetime.now(timezone(timedelta(hours=1)))
-    period = DeliveryPeriod(start=start, duration=timedelta(minutes=5))
-
-    assert period.start.tzinfo == timezone.utc
-    assert start.hour == period.start.hour + 1
+    with pytest.raises(ValueError):
+        DeliveryPeriod(
+            start=datetime.now(timezone(timedelta(hours=1))),
+            duration=DeliveryDuration.MINUTES_5,
+        )
 
 
 def test_delivery_area_to_pb() -> None:


### PR DESCRIPTION
This includes a breaking change.  `DeliveryPeriod` instances now require a `DeliveryDuration` instance, and can't be instantiated from `timedelta`s anymore.