### PR TITLE
Expose get_gridpool_order command to CLI

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,7 +10,7 @@
 
 ## New Features
 
-<!-- Here goes the main new features and examples or instructions on how to use them -->
+* Added a new `get-gridpool-order` CLI command to fetch a single order by gridpool ID and order ID.
 
 ## Bug Fixes
 

--- a/src/frequenz/client/electricity_trading/cli/__main__.py
+++ b/src/frequenz/client/electricity_trading/cli/__main__.py
@@ -17,6 +17,9 @@ from frequenz.client.electricity_trading.cli.etrading import (
     create_order as run_create_order,
 )
 from frequenz.client.electricity_trading.cli.etrading import (
+    get_gridpool_order as run_get_gridpool_order,
+)
+from frequenz.client.electricity_trading.cli.etrading import (
     list_gridpool_orders as run_list_gridpool_orders,
 )
 from frequenz.client.electricity_trading.cli.etrading import (
@@ -272,6 +275,27 @@ def cancel_all_orders(
             auth_key=auth_key,
             gridpool_id=gid,
             order_id=None,
+            sign_secret=sign_secret,
+        )
+    )
+
+
+@cli.command()
+@click.option("--url", required=True, type=str)
+@click.option("--auth_key", required=True, type=str)
+@click.option("--gid", required=True, type=int)
+@click.option("--order", required=True, type=int)
+@click.option("--sign_secret", default=None, type=str)
+def get_gridpool_order(
+    url: str, auth_key: str, gid: int, order: int, sign_secret: str | None = None
+) -> None:
+    """Get a single order for a gridpool ID."""
+    asyncio.run(
+        run_get_gridpool_order(
+            url=url,
+            auth_key=auth_key,
+            gridpool_id=gid,
+            order_id=order,
             sign_secret=sign_secret,
         )
     )

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -306,6 +306,29 @@ async def cancel_order(
         await client.cancel_gridpool_order(gridpool_id, order_id=order_id)
 
 
+async def get_gridpool_order(
+    url: str,
+    auth_key: str,
+    *,
+    gridpool_id: int,
+    order_id: int,
+    sign_secret: str | None = None,
+) -> None:
+    """Fetch and print a single order by gridpool ID and order ID.
+
+    Args:
+        url: URL of the trading API.
+        auth_key: API key.
+        gridpool_id: Gridpool ID for the order to retrieve.
+        order_id: Order ID of the order to retrieve within the gridpool.
+        sign_secret: The cryptographic secret to use for HMAC generation.
+    """
+    client = Client(server_url=url, auth_key=auth_key, sign_secret=sign_secret)
+    order = await client.get_gridpool_order(gridpool_id=gridpool_id, order_id=order_id)
+    print_order_header()
+    print_order(order=order, gid=gridpool_id)
+
+
 def print_public_trade_header() -> None:
     """Print trade header in CSV format."""
     header = (


### PR DESCRIPTION
Add a dedicated CLI command to fetch one gridpool order by ID so that users can inspect a specific order without listing and filtering all orders.
