### PR TITLE
Fix delivery_to filter wording in CLI and helper docs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,4 +14,4 @@
 
 ## Bug Fixes
 
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->
+* Fixed CLI helper and help documentation for `delivery-to` filters to refer to delivery end times instead of start times.

--- a/src/frequenz/client/electricity_trading/cli/__main__.py
+++ b/src/frequenz/client/electricity_trading/cli/__main__.py
@@ -120,7 +120,7 @@ def receive_public_orders(  # pylint: disable=too-many-arguments
     "--delivery-to",
     default=None,
     type=iso,
-    help="End timestamp (exclusive) to filter delivery start times.",
+    help="End timestamp (exclusive) to filter delivery end times.",
 )
 @click.option("--sign_secret", default=None, type=str)
 def receive_gridpool_trades(
@@ -159,7 +159,7 @@ def receive_gridpool_trades(
     "--delivery-to",
     default=None,
     type=iso,
-    help="End timestamp (exclusive) to filter delivery start times.",
+    help="End timestamp (exclusive) to filter delivery end times.",
 )
 @click.option("--gid", required=True, type=int)
 @click.option("--sign_secret", default=None, type=str)

--- a/src/frequenz/client/electricity_trading/cli/etrading.py
+++ b/src/frequenz/client/electricity_trading/cli/etrading.py
@@ -144,7 +144,7 @@ async def list_gridpool_trades(
         auth_key: API key.
         gid: Gridpool ID.
         delivery_from: Start timestamp (inclusive) to filter delivery start times or None.
-        delivery_to: End timestamp (exclusive) to filter delivery start times or None.
+        delivery_to: End timestamp (exclusive) to filter delivery end times or None.
         sign_secret: The cryptographic secret to use for HMAC generation.
     """
     client = Client(server_url=url, auth_key=auth_key, sign_secret=sign_secret)
@@ -191,7 +191,7 @@ async def list_gridpool_orders(
         url: URL of the trading API.
         auth_key: API key.
         delivery_from: Start timestamp (inclusive) to filter delivery start times or None.
-        delivery_to: End timestamp (exclusive) to filter delivery start times or None.
+        delivery_to: End timestamp (exclusive) to filter delivery end times or None.
         gid: Gridpool ID.
         sign_secret: The cryptographic secret to use for HMAC generation.
     """


### PR DESCRIPTION
Align CLI option help and helper docstrings to describe `--delivery-to` as a delivery end-time filter rather than a delivery start-time filter.
